### PR TITLE
Bug fix for case when P-H keys are not found

### DIFF
--- a/src/read_snapshot/particles_in_box/utility.jl
+++ b/src/read_snapshot/particles_in_box/utility.jl
@@ -252,6 +252,12 @@ function find_files_for_keys(filebase::String, nfiles::Integer, keylist::Vector{
 
     index_bounds = get_index_bounds(keylist[key_sort], low_list, high_list)
 
+    # bug fix for case when get_index_bounds returns -1:
+    # treat as if no index file existed
+    if index_bounds == -1
+        return collect(0:nfiles-1)
+    end
+
     file_sort = sort(file_list[index_bounds])
 
     return Int64.(file_sort)


### PR DESCRIPTION
Treat get_index_bounds returning -1 (which leads to a BoundsError) the
same way as when there is no Peanu-Hilbert index file available:
All key files need to be read.