### PR TITLE
Bug fix: Vector to AbstractVector

### DIFF
--- a/src/read_snapshot/particles_in_box/utility.jl
+++ b/src/read_snapshot/particles_in_box/utility.jl
@@ -386,7 +386,7 @@ end
     
 Joins neighboring blocks to simplify read-in.
 """
-@inline function join_blocks(offset_key::Vector{<:Integer}, part_per_key::Vector{<:Integer})
+@inline function join_blocks(offset_key::AbstractVector{<:Integer}, part_per_key::AbstractVector{<:Integer})
 
     use_block = trues(length(offset_key))
 


### PR DESCRIPTION
Fixes case when a view of a vector gets passed instead of a pure vector.