### PR TITLE
Improve read

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GadgetIO"
 uuid = "826b50da-1eb7-48f3-bd4b-d2350582c309"
 authors = ["LudwigBoess <lboess@usm.lmu.de>"]
-version = "0.5.9"
+version = "0.6.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/read_snapshot/particles_in_halo/read_particles_by_id.jl
+++ b/src/read_snapshot/particles_in_halo/read_particles_by_id.jl
@@ -196,6 +196,9 @@ function read_particles_by_id(snap_base::String, selected_ids::Array{<:Integer},
                 # update number of read particles
                 N_read += N_this_file
 
+                if N_read == N_to_read
+                    break
+                end
             end
 
             # reduce array size

--- a/src/read_snapshot/particles_in_halo/read_particles_by_id.jl
+++ b/src/read_snapshot/particles_in_halo/read_particles_by_id.jl
@@ -54,6 +54,10 @@ function read_particles_by_id_single_file(snap_file::String, halo_ids::Array{<:I
         @info "Found $(size(matched,1)) matches. Took: $(t2 - t1)"
     end
 
+    if length(matched) == 0
+        return nothing
+    end
+
     # store block positions for faster read-in
     block_positions = get_block_positions(snap_file)
 
@@ -180,6 +184,10 @@ function read_particles_by_id(snap_base::String, selected_ids::Array{<:Integer},
 
                 # read data from file
                 data_file = read_particles_by_id_single_file(filename, selected_ids, blocks, parttype, verbose=verbose)
+
+                if isnothing(data_file)
+                    continue
+                end
 
                 N_this_file = size(data_file["ID"],1)
 

--- a/src/read_snapshot/particles_in_halo/read_particles_in_halo.jl
+++ b/src/read_snapshot/particles_in_halo/read_particles_in_halo.jl
@@ -49,9 +49,6 @@ function read_pids(sub_base::String, N_ids::Integer, offset::Integer)
                 offset_remaining -= sub_header.nfof
                 continue
             else
-                # find starting position for read-in
-                start_pos = offset_remaining + 1
-                
                 # number of particles remaining to be read
                 if ( sub_header.nfof - offset_remaining < N_ids - ids_read )
                     n_to_read = sub_header.nfof - offset_remaining
@@ -59,7 +56,7 @@ function read_pids(sub_base::String, N_ids::Integer, offset::Integer)
                     n_to_read = N_ids - ids_read
                 end
 
-                ids[ids_read+1:ids_read+n_to_read] = read_subfind(sub_file, "PID")[start_pos:start_pos+n_to_read-1]
+                read_subfind!(@view(ids[(ids_read+1):(ids_read+n_to_read)]), sub_file, "PID"; offset=offset_remaining)
 
                 # update number of IDs alrady read
                 ids_read += n_to_read
@@ -72,9 +69,8 @@ function read_pids(sub_base::String, N_ids::Integer, offset::Integer)
 
         return ids
     else # they can be read from one file
-        # position of first ID in array
-        start_pos = offset + 1
-        return read_subfind(sub_file, "PID")[start_pos:start_pos+N_ids-1]
+        ids = Vector{pid_info.data_type}(undef, N_ids)
+        return read_subfind!(ids, sub_file, "PID"; offset)
     end
 end
 

--- a/src/read_snapshot/read_format_2.jl
+++ b/src/read_snapshot/read_format_2.jl
@@ -211,12 +211,8 @@ function read_subsnaps(filebase::String, blockname::String, parttype::Integer,
 
         # read the block
         if info.n_dim > 1
-            # block[:, N_read+1:N_read+N_to_read] = read_block(filename, blockname;
-                                                            # parttype, info, h)
             read_block!(@view(block[:, (N_read+1):(N_read+N_to_read)]), filename, blockname; parttype, info, h)
         else
-            # block[N_read+1:N_read+N_to_read]    = read_block(filename, blockname;
-                                                            # parttype, info, h)
             read_block!(@view(block[(N_read+1):(N_read+N_to_read)]), filename, blockname; parttype, info, h)
         end
 

--- a/src/read_snapshot/read_format_2.jl
+++ b/src/read_snapshot/read_format_2.jl
@@ -415,7 +415,6 @@ function read_block_with_offset!(data, n_read::Integer, filename::String, pos0::
     # store position in file
     p = position(f)
 
-    n_read = Int(n_read) # needed for reading into a view of an array
     n_this_key = n_read 
 
     for i = 1:size(offset_key,1)
@@ -424,10 +423,11 @@ function read_block_with_offset!(data, n_read::Integer, filename::String, pos0::
         seek(f, p + len*offset_key[i])
         n_this_key += part_per_key[i]
 
+        # note the Int(...) are necessary to enable the reading into the SubArray returned by @view
         if info.n_dim == 1
-            read_block_data!(@view(data[(n_read+1):n_this_key]), f, info.data_type, info.n_dim, part_per_key[i])
+            read_block_data!(@view(data[Int(n_read+1):Int(n_this_key)]), f, info.data_type, info.n_dim, part_per_key[i])
         else
-            read_block_data!(@view(data[:, (n_read+1):n_this_key]), f, info.data_type, info.n_dim, part_per_key[i])
+            read_block_data!(@view(data[:, Int(n_read+1):Int(n_this_key)]), f, info.data_type, info.n_dim, part_per_key[i])
         end
 
         n_read += part_per_key[i]

--- a/src/read_snapshot/read_format_2.jl
+++ b/src/read_snapshot/read_format_2.jl
@@ -415,7 +415,7 @@ function read_block_with_offset!(data, n_read::Integer, filename::String, pos0::
     # store position in file
     p = position(f)
 
-    n_read = Int64(n_read) # needed for reading into a view of an array
+    n_read = Int(n_read) # needed for reading into a view of an array
     n_this_key = n_read 
 
     for i = 1:size(offset_key,1)

--- a/src/read_snapshot/utility/snapshot_utilities.jl
+++ b/src/read_snapshot/utility/snapshot_utilities.jl
@@ -8,10 +8,10 @@ function check_blocksize(f::IOStream, position_before::Integer, blocksize_before
     seek(f,position_before+blocksize_before+12)
     blocksize_after = read(f,UInt32)
 
-    # of the numbers are the same everything works as it should
+    # if the numbers are the same everything works as it should
     if blocksize_before == blocksize_after
         return blocksize_before
-    else
+    else # compensate for integer overflow
         blocksize_before_fix = blocksize_before + 4294967296
         seek(f,position_before+blocksize_before_fix+12) 
         blocksize_after_fix = read(f,UInt32) + 4294967296

--- a/src/read_subfind/read_subfind.jl
+++ b/src/read_subfind/read_subfind.jl
@@ -158,7 +158,7 @@ end
 
 Reads a block of a subfind file.
 """
-function read_subfind(filename::String, blockname::String)
+function read_subfind(filename::String, blockname::String; offset=0, nread=-1)
     
     # read the info block
     info = read_info(filename)
@@ -177,7 +177,7 @@ function read_subfind(filename::String, blockname::String)
     # blocks are type specific so we can use this to make our life easier
     parttype = findfirst(==(1), info_selected.is_present) - 1
 
-    return read_block(filename, blockname, info = info_selected, parttype = parttype)
+    return read_block(filename, blockname; info = info_selected, parttype, offset, nread)
 end
 
 """

--- a/src/read_subfind/read_subfind.jl
+++ b/src/read_subfind/read_subfind.jl
@@ -180,6 +180,30 @@ function read_subfind(filename::String, blockname::String; offset=0, nread=-1)
     return read_block(filename, blockname; info = info_selected, parttype, offset, nread)
 end
 
+function read_subfind_length(filename::String, blockname::String)
+    
+    # read the info block
+    info = read_info(filename)
+
+    blocknames = getfield.(info, :block_name)
+    ind = findfirst(==(blockname), blocknames)
+
+    # the the block is not contained in the file throw and error
+    if isnothing(ind)
+        error("Block $blockname not present!")
+    end
+
+    # get the relevant entry
+    info_selected = info[ind]
+
+    # blocks are type specific so we can use this to make our life easier
+    parttype = findfirst(==(1), info_selected.is_present) - 1
+
+    h = head_to_obj(filename)
+
+    return h.npart[parttype+1]
+end
+
 """
     read_subfind!(a::AbstractArray, filename, blockname::String)
 

--- a/src/read_subfind/read_subfind.jl
+++ b/src/read_subfind/read_subfind.jl
@@ -179,3 +179,30 @@ function read_subfind(filename::String, blockname::String)
 
     return read_block(filename, blockname, info = info_selected, parttype = parttype)
 end
+
+"""
+    read_subfind!(a::AbstractArray, filename, blockname::String)
+
+Reads a block of a subfind file into a.
+"""
+function read_subfind!(a::AbstractArray, filename, blockname::String; offset=0)
+    
+    # read the info block
+    info = read_info(filename)
+
+    blocknames = getfield.(info, :block_name)
+    ind = findfirst(==(blockname), blocknames)
+
+    # the the block is not contained in the file throw and error
+    if isnothing(ind)
+        error("Block $blockname not present!")
+    end
+
+    # get the relevant entry
+    info_selected = info[ind]
+
+    # blocks are type specific so we can use this to make our life easier
+    parttype = findfirst(==(1), info_selected.is_present) - 1
+
+    return read_block!(a, filename, blockname; info = info_selected, parttype, offset)
+end


### PR DESCRIPTION
I'm opening this pull request as a draft, to which we can continue adding commits with tests, docs, and probably clean up the code a bit (I copy pasted a bunch of things that would probably be better in individual functions).

But before starting to work on that front, it would be great to have another pair of eyes look at the code. I tried my best to compare each of the modified reading routines between master and this branch for different inputs, but oversights can always happen.

The changes introduce reading directly to arrays instead of copying multiple arrays into a large arrays. This is done by reading into subarrays given by @view. Other improvements include:

- jumping the read pointer ahead in memory before reading in (e.g. when reading in a property of an individual halo)
- reading in prefiltered data (e.g. when brute-force reading particles by PID)
- stop reading files when all particles in list of PIDs have been found

As an example for the improved speed, calling read_snap(snapbase, "POS", 0) for a simulation with around 180 million particles is now twice as fast.