### PR TITLE
Fix multi file read

### DIFF
--- a/src/read_snapshot/particles_in_box/read_particle_in_box.jl
+++ b/src/read_snapshot/particles_in_box/read_particle_in_box.jl
@@ -138,6 +138,11 @@ function read_particles_in_box_peano(filename::String, blocks::Vector{String},
         # read header
         h = read_header(filename)
 
+        # no particles of parttype in the file
+        if h.npart[parttype+1] == 0
+            continue
+        end
+
         # read info block
         snap_info = read_info(filename)
 

--- a/src/read_snapshot/particles_in_box/utility.jl
+++ b/src/read_snapshot/particles_in_box/utility.jl
@@ -26,11 +26,17 @@ function find_read_positions(files::Vector{<:Integer}, filebase::String,
 
         filename = select_file(filebase, files[i])
 
-        # read header of the file
+        # read header and key info of the file
         h = head_to_obj(filename)
+        key_info  = read_info(filename * ".key")
 
         if h.npart[parttype+1] == 0
-            error("No particles of type $parttype in file!")
+            @info "No particles of type $parttype in file $(i)!"
+            # store the arrays for later reading
+            file_offset_key[i]   = Int[]
+            file_part_per_key[i] = Int[]
+            file_block_positions[i] = Dict{String,Int}()
+            continue
         end
 
         filename_keyfile = filename * ".key"

--- a/src/read_snapshot/read_format_2.jl
+++ b/src/read_snapshot/read_format_2.jl
@@ -159,13 +159,13 @@ function read_subsnaps(filebase::String, blockname::String, parttype::Integer,
         # get number of particles for this sub-file
         N_to_read = h.npart[parttype+1]
 
-        # read the block
+        # read the block (info has to be read individually for each file)
         if info.n_dim > 1
             block[:, N_read+1:N_read+N_to_read] = read_block(filename, blockname;
-                                                            parttype, info, h)
+                                                            parttype, h)
         else
             block[N_read+1:N_read+N_to_read]    = read_block(filename, blockname;
-                                                            parttype, info, h)
+                                                            parttype, h)
         end
 
         # update number of read particles

--- a/src/read_snapshot/read_format_2.jl
+++ b/src/read_snapshot/read_format_2.jl
@@ -156,16 +156,21 @@ function read_subsnaps(filebase::String, blockname::String, parttype::Integer,
         # read header of subfile
         h = read_header(filename)
 
+        info = check_info(filebase * ".$i", blockname)
+        if info.is_present[parttype+1] == 0
+            continue
+        end
+
         # get number of particles for this sub-file
         N_to_read = h.npart[parttype+1]
 
         # read the block (info has to be read individually for each file)
         if info.n_dim > 1
             block[:, N_read+1:N_read+N_to_read] = read_block(filename, blockname;
-                                                            parttype, h)
+                                                            parttype, info, h)
         else
             block[N_read+1:N_read+N_to_read]    = read_block(filename, blockname;
-                                                            parttype, h)
+                                                            parttype, info, h)
         end
 
         # update number of read particles

--- a/src/read_snapshot/utility/domain_slices.jl
+++ b/src/read_snapshot/utility/domain_slices.jl
@@ -8,6 +8,11 @@ Reads positions from `snap_file` and returns the indices of particles contained 
 """
 function filter_cube(snap_file::String, corner_lowerleft::Array{<:Real}, corner_upperright::Array{<:Real}; parttype::Integer=0)
 
+    # parttype not in subfile
+    if check_info(snap_file, "POS").is_present[parttype+1] == 0
+        return Int[]
+    end
+
     # read positions from file
     pos = read_snap(snap_file, "POS", parttype)
 


### PR DESCRIPTION
GadgetIO threw errors or read incorrect particles when only some of the subfiles contain a certain particle type.
This pull request catches the errors thrown when individual subfiles do not contain the wanted particle type and reads the info line for each file when needed instead of passing the info line of the first subfile to all others.