### PR TITLE
Minor enhancements

### DIFF
--- a/src/read_snapshot/particles_in_halo/read_particles_in_halo.jl
+++ b/src/read_snapshot/particles_in_halo/read_particles_in_halo.jl
@@ -139,8 +139,6 @@ function read_ids_in_halo( sub_base::String, halo::HaloID;
     # read all IDs of the particles contained in a halo
     halo_ids = read_pids(sub_base, N_ids, offset)
 
-    println("pids done")
-
     if verbose
         t2 = Dates.now()
         @info "IDs read. Took: $(t2 - t1)"

--- a/src/read_subfind/halo_ids.jl
+++ b/src/read_subfind/halo_ids.jl
@@ -18,7 +18,7 @@ end
 
 Converts global halo indices to `HaloID`s.
 """
-function global_idxs_to_halo_id(sub_base::String, idxs::Vector{<:Integer}; 
+function global_idxs_to_halo_id(sub_base::String, idxs::AbstractVector{<:Integer}; 
                                 parttype::Integer=0)
 
     # idxs are 0-indexed
@@ -89,7 +89,7 @@ function global_idxs_to_halo_id(sub_base::String, offset::Integer, n_to_read::In
         finish_read = offset + n_to_read
     end
 
-    idxs = collect(offset:finish_read)
+    idxs = offset:finish_read
 
     return global_idxs_to_halo_id(sub_base, idxs; parttype)
 end


### PR DESCRIPTION
Allow getting HaloIDs for any kinds of AbstractVectors (e.g. UnitRange and StepRange like 0:10000).

Also removes a print statement after reading the PIDs of a halo that also printed when verbose=false.