### PR TITLE
Read header and info block for all files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GadgetIO"
 uuid = "826b50da-1eb7-48f3-bd4b-d2350582c309"
 authors = ["LudwigBoess <lboess@usm.lmu.de>"]
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/read_snapshot/read_format_2.jl
+++ b/src/read_snapshot/read_format_2.jl
@@ -117,11 +117,12 @@ function read_block(filename::String, blockname::String;
         
         # read local filename
         _filename = select_file(filename, file)
+        h = read_header(_filename)
+        info = check_info(_filename, blockname)
 
         # get number of particles to read from local file, if not given
         if (h.num_files > 1) && (!n_read_io)
-            h_internal = read_header(_filename)
-            n_to_read  = h_internal.npart[parttype+1]
+            n_to_read = h.npart[parttype+1]
         end
 
         # find block position, if not given

--- a/src/read_snapshot/read_format_2.jl
+++ b/src/read_snapshot/read_format_2.jl
@@ -95,6 +95,7 @@ function read_block(filename::String, blockname::String;
     end
 
     # check if info is present
+    was_info_given = !isnothing(info)
     if isnothing(info)
         info = check_info(filename, blockname)
     end
@@ -118,7 +119,11 @@ function read_block(filename::String, blockname::String;
         # read local filename
         _filename = select_file(filename, file)
         h = read_header(_filename)
-        info = check_info(_filename, blockname)
+
+        # read info individually for the file if no info block was passed
+        if !was_info_given
+            info = check_info(_filename, blockname)
+        end
 
         # get number of particles to read from local file, if not given
         if (h.num_files > 1) && (!n_read_io)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,6 +44,9 @@ Downloads.download("http://www.usm.uni-muenchen.de/~lboess/GadgetIO/snap_144.3.k
 
 Downloads.download("http://www.usm.uni-muenchen.de/~lboess/GadgetIO/snap_144.key.index", "./snap_144.key.index")
 
+Downloads.download("http://www.usm.uni-muenchen.de/~lboess/GadgetIO/snap_mass_144.0", "./snap_mass_144.0")
+Downloads.download("http://www.usm.uni-muenchen.de/~lboess/GadgetIO/snap_mass_144.1", "./snap_mass_144.1")
+
 @info "done!"
 
 
@@ -567,5 +570,8 @@ rm("snap_144.1.key")
 rm("snap_144.2.key")
 rm("snap_144.3.key")
 rm("snap_144.key.index")
+
+rm("snap_mass_144.0")
+rm("snap_mass_144.1")
 
 @info "done!"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -561,6 +561,7 @@ end
 @info "delete test data..."
 rm("snap_sedov")
 rm("pos_sedov.dat")
+rm("halo_ids.dat")
 rm("sub_002.0")
 rm("sub_002.1")
 rm("sub_002.2")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -229,6 +229,21 @@ Downloads.download("http://www.usm.uni-muenchen.de/~lboess/GadgetIO/snap_mass_14
             rm("dummy.bin")
         end
 
+        @testset "Read files different infolines" begin
+            subbase = "./snap_mass_144"
+            subfile0 = "$subbase.0"
+            subfile1 = "$subbase.1"
+
+            mass = read_block(subbase, "MASS"; parttype=4)
+            mass0 = read_block(subfile0, "MASS"; parttype=4)
+            mass1 = read_block(subfile1, "MASS"; parttype=4)
+
+            # check that reading mass did not read boundary particles by accident;
+            # the reason is that the first file does not have particle type 3, but
+            # the second file does
+            @test mass == [mass0; mass1]
+        end
+
         @testset "Error Handling" begin
             #@test_throws ErrorException("Please specify particle type!") read_block("snap_002.0", "POS")
             @test_throws ErrorException("Particle Type 5 not present in simulation!") read_block("snap_002.0", "POS", parttype=5, h=SnapshotHeader())


### PR DESCRIPTION
This fixes issues when different subfiles contain different particle types.