### PR TITLE
Fix reading mass block

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GadgetIO"
 uuid = "826b50da-1eb7-48f3-bd4b-d2350582c309"
 authors = ["LudwigBoess <lboess@usm.lmu.de>"]
-version = "0.7.7"
+version = "0.7.8"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/read_snapshot/read_format_2.jl
+++ b/src/read_snapshot/read_format_2.jl
@@ -147,9 +147,14 @@ function read_block(filename::String, blockname::String;
             # read block position, if not given
             block_position, mass_block = check_block_position(_filename, blockname)
 
-            if mass_block
-                assign_mass_from_header!(block, _filename, h, parttype) 
-                return block
+            if parttype != -1 && info.is_present[parttype+1] == 0
+                if mass_block
+                    assign_mass_from_header!(block, _filename, h, parttype) 
+                    return block
+                else
+                    # if the block is not present we need error handling!
+                    error("Requested block $blockname not present for particle type $(parttype)!")
+                end
             end
         end
 

--- a/src/read_snapshot/read_format_2.jl
+++ b/src/read_snapshot/read_format_2.jl
@@ -147,14 +147,22 @@ function read_block(filename::String, blockname::String;
             # read block position, if not given
             block_position, mass_block = check_block_position(_filename, blockname)
 
-            if parttype != -1 && info.is_present[parttype+1] == 0
-                if mass_block
-                    assign_mass_from_header!(block, _filename, h, parttype) 
-                    return block
-                else
+            if parttype == -1
+                # make sure the property exists for all particle types
+                for ptype = 0:5
+                    if !iszero(h.npart[ptype+1]) && iszero(info.is_present[ptype+1])
+                        error("Requested block $blockname not present for particle type $(ptype)!")
+                    end
+                end
+            elseif parttype != -1 && info.is_present[parttype+1] == 0
+                # TODO: special case mass block
+                # if mass_block
+                    # assign_mass_from_header!(block, _filename, h, parttype) 
+                    # return block
+                # else
                     # if the block is not present we need error handling!
                     error("Requested block $blockname not present for particle type $(parttype)!")
-                end
+                # end
             end
         end
 


### PR DESCRIPTION
A bug was introduced that only read the mass from the mass table in the header, which resulted in arrays of only zeros for particle types that actually have real mass blocks instead of an entry in the header mass table (e.g. reading MASS for gas particles resulted in all particles having mass 0).

Starting with this change it also throws an error when the respective block is present, but not for the specified particle type (e.g. reading TEMP for DM particles used to read random stuff).