### PR TITLE
Fix integer overflow in write block

### DIFF
--- a/src/write_snapshot/write_snap.jl
+++ b/src/write_snapshot/write_snap.jl
@@ -59,15 +59,16 @@ function write_block(f::IOStream, data,
         dims = size(data,1)
     end
 
+    # compute size of block in bytes
     blocksize_test = N * sizeof(dtype) * dims
 
     # check for integer overflow
-    if blocksize_test <= typemax(UInt32)
-        blocksize = UInt32(blocksize_test)
-    else
-        # avoid integer overflow
-        blocksize = UInt32(blocksize_test - 4294967296)
+    while blocksize_test > typemax(UInt32)
+        blocksize_test -= 4294967296
     end
+
+    # save blocksize in UInt32
+    blocksize = UInt32(blocksize_test)
 
     if snap_format == 2
 


### PR DESCRIPTION
This PR fixes an issue when trying to write very large single snapshot files. If the block is so large that the blocksize doesn't fit into an `UInt32` you get a truncation error. Previously this was only handled when reading blocks and then only if the blocksize only caused one integer overflow.
Now it's handled for writing as well and handles up to 10 integer overflows when reading.
This allows to write very large single files (I tested it with a 20GB single file).