### PR TITLE
Fix reading PIDs in multiple files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GadgetIO"
 uuid = "826b50da-1eb7-48f3-bd4b-d2350582c309"
 authors = ["LudwigBoess <lboess@usm.lmu.de>"]
-version = "0.7.11"
+version = "0.7.12"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/read_snapshot/particles_in_halo/read_particles_in_halo.jl
+++ b/src/read_snapshot/particles_in_halo/read_particles_in_halo.jl
@@ -1,11 +1,11 @@
 using Dates
 
 """
-    read_pids(sub_base::String, offset::Int64, N_ids::Int64)
+    read_pids(sub_base::String, offset::Signed, N_ids::Signed)
 
 Reads the `PID` block in the subfind output.
 """
-function read_pids(sub_base::String, N_ids::Int64, offset::Int64)
+function read_pids(sub_base::String, N_ids::Signed, offset::Signed)
 
     # choose correct file
     sub_file = select_file(sub_base, 0)

--- a/src/read_snapshot/particles_in_halo/read_particles_in_halo.jl
+++ b/src/read_snapshot/particles_in_halo/read_particles_in_halo.jl
@@ -1,11 +1,11 @@
 using Dates
 
 """
-    read_pids(sub_base::String, offset::Integer, N_ids::Integer)
+    read_pids(sub_base::String, offset::Int, N_ids::Int)
 
 Reads the `PID` block in the subfind output.
 """
-function read_pids(sub_base::String, N_ids::Integer, offset::Integer)
+function read_pids(sub_base::String, N_ids::Int, offset::Int)
 
     # choose correct file
     sub_file = select_file(sub_base, 0)
@@ -61,7 +61,7 @@ function read_pids(sub_base::String, N_ids::Integer, offset::Integer)
 
                 f = open(sub_file)
 
-                read_block!(@view(ids[(ids_read+1):(ids_read+n_to_read)]), f, 
+                read_block!(ids, f, 
                             offset_remaining, ids_read, n_to_read,
                             info=pid_info, parttype=2;
                             block_position, h)

--- a/src/read_snapshot/particles_in_halo/read_particles_in_halo.jl
+++ b/src/read_snapshot/particles_in_halo/read_particles_in_halo.jl
@@ -1,11 +1,11 @@
 using Dates
 
 """
-    read_pids(sub_base::String, offset::Int, N_ids::Int)
+    read_pids(sub_base::String, offset::Int64, N_ids::Int64)
 
 Reads the `PID` block in the subfind output.
 """
-function read_pids(sub_base::String, N_ids::Int, offset::Int)
+function read_pids(sub_base::String, N_ids::Int64, offset::Int64)
 
     # choose correct file
     sub_file = select_file(sub_base, 0)


### PR DESCRIPTION
Bug was thrown when PIDs were spread out over multiple files because code attempted to view into a view. Additionally, the types of length and offset are now restricted to Int because UInt silently gave wrong results (since everything was then converted to UInt, leading to only positive values when comparing lengths which should have been negative).