### PR TITLE
Fix ph keys beyond border

### DIFF
--- a/src/GadgetIO.jl
+++ b/src/GadgetIO.jl
@@ -184,7 +184,7 @@ using Downloads
 
         keylist = GadgetIO.get_keylist(h_key, x0, x1)
 
-        GadgetIO.get_int_pos(1000.5, h_key.domain_corners[1], h_key.domain_fac)
+        GadgetIO.get_int_pos(1000.5, h_key.domain_corners[1], h_key.domain_fac, h_key.bits)
     end
 
 end

--- a/src/read_snapshot/particles_in_box/peano_hilbert.jl
+++ b/src/read_snapshot/particles_in_box/peano_hilbert.jl
@@ -3,8 +3,13 @@
 
 Computes the integer position along the PH line.
 """
-@inline function get_int_pos(pos::Real, domain_corner::Real, domain_fac::Real )
-    return trunc(Int64, ( pos - domain_corner ) * domain_fac) 
+@inline function get_int_pos(pos::Real, domain_corner::Real, domain_fac::Real, bits::Integer )
+    val = (pos - domain_corner) * domain_fac 
+
+    # round down, but negative values have to be reduced by one and values beyond the box border increased by one (unclear why exactly, probably due to how the bits work out, but this was carefully tested to be sure that this version works)
+    val_int = floor(Int64, val) + ifelse(val ≥ 0, 0, -1) + ifelse(val ≥ 2^bits - 0.5, 1, 0) 
+
+    return val_int
 end
 
 """
@@ -157,8 +162,8 @@ function get_keylist(h_key::KeyHeader, x0::Array{T}, x1::Array{T}) where T
     nkeys = 1
 
     @inbounds for i = 1:3
-        ix0[i] = get_int_pos( x0[i], h_key.domain_corners[i], h_key.domain_fac )
-        ix1[i] = get_int_pos( x1[i], h_key.domain_corners[i], h_key.domain_fac )
+        ix0[i] = get_int_pos( x0[i], h_key.domain_corners[i], h_key.domain_fac, h_key.bits )
+        ix1[i] = get_int_pos( x1[i], h_key.domain_corners[i], h_key.domain_fac, h_key.bits )
         dix[i] = ix1[i] - ix0[i] + 1
         nkeys *= dix[i]
     end

--- a/src/read_snapshot/particles_in_box/peano_hilbert.jl
+++ b/src/read_snapshot/particles_in_box/peano_hilbert.jl
@@ -1,5 +1,5 @@
 """
-    get_int_pos(pos::Real, domain_corner::Real, domain_fac::Real )
+    get_int_pos(pos::Real, domain_corner::Real, domain_fac::Real, bits::Integer)
 
 Computes the integer position along the PH line.
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -560,7 +560,7 @@ Downloads.download("http://www.usm.uni-muenchen.de/~lboess/GadgetIO/balance.txt"
         @test GadgetIO.peano_hilbert_key(h_key.bits, 0, 0, 1) == 1
         @test GadgetIO.peano_hilbert_key(h_key.bits, 0, 1, 1) == 6
 
-        @test GadgetIO.get_int_pos(1000.5, h_key.domain_corners[1], h_key.domain_fac) == 1
+        @test GadgetIO.get_int_pos(1000.5, h_key.domain_corners[1], h_key.domain_fac, h_key.bits) == 1
 
         @testset "Get Index Bounds" begin
             low_bounds, high_bounds = [0, 4, 7, 10], [1, 5, 8, 16]


### PR DESCRIPTION
For negative coordinates and coordinates beyond the box size, get_int_pos returned PH-keys offset by one. It is not clear why that is exactly (probably due to how the bits are handled, and the IDL version does it wrong, too), but the current implementation in this pull request works.