### PR TITLE
Fix read all particles

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GadgetIO"
 uuid = "826b50da-1eb7-48f3-bd4b-d2350582c309"
 authors = ["LudwigBoess <lboess@usm.lmu.de>"]
-version = "0.7.14"
+version = "0.7.15"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/read_snapshot/read_format_2.jl
+++ b/src/read_snapshot/read_format_2.jl
@@ -319,8 +319,13 @@ function read_all_parttypes(filename::String, blockname::String;
     for parttype = 0:5
         # only read the block if particles are actually present
         if !iszero(n_to_read[parttype+1])
-            block[Int(nread + 1):Int(nread + n_to_read[parttype+1])] = read_block(filename, blockname, parttype=parttype,
-                                                            block_position=block_position, info=info, h=h)
+            if info.n_dim == 1
+                    block[Int(nread + 1):Int(nread + n_to_read[parttype+1])] = read_block(filename, blockname, parttype=parttype,
+                                                                    block_position=block_position, info=info, h=h)
+            else
+                    block[:, Int(nread + 1):Int(nread + n_to_read[parttype+1])] = read_block(filename, blockname, parttype=parttype,
+                                                                    block_position=block_position, info=info, h=h)
+            end
             nread += n_to_read[parttype+1]
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -153,6 +153,21 @@ Downloads.download("http://www.usm.uni-muenchen.de/~lboess/GadgetIO/balance.txt"
 
                 @test id_full == id
 
+
+                pos = zeros(Float32, 3, n_all)
+                n_read = 0
+                for parttype = 0:5
+                    n_to_read = h.npart[parttype+1]
+                    if !iszero(n_to_read)
+                        pos[:, n_read+1:n_read+n_to_read] = read_block(snap_file, "POS"; parttype)
+                        n_read += n_to_read
+                    end
+                end
+
+                pos_full = read_block(snap_file, "POS", parttype=-1)
+
+                @test pos_full == pos
+
                 # distributed files
                 # ToDo!
             end


### PR DESCRIPTION
Previously it would error if one used read_block on 2D properties like POS or VEL for all particles (parttype=-1).